### PR TITLE
Vendor hardware.inc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/include/hardware.inc"]
-	path = include/hardware.inc
-	url = https://github.com/gbdev/hardware.inc.git

--- a/scripts/update_hardware_inc.sh
+++ b/scripts/update_hardware_inc.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+HARDWARE_INC_URL='https://raw.githubusercontent.com/gbdev/hardware.inc/refs/heads/master/hardware.inc'
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+curl "${HARDWARE_INC_URL}" -o "${GIT_ROOT}/include/hardware.inc"

--- a/src/header.asm
+++ b/src/header.asm
@@ -1,5 +1,5 @@
 
-INCLUDE "hardware.inc/hardware.inc"
+INCLUDE "hardware.inc"
 	rev_Check_hardware_inc 4.0
 
 SECTION "Header", ROM0[$100]


### PR DESCRIPTION
Providing `hardware.inc` as a submodule presents a set of challenges for a Github template as git doesn't fetch submodules by default, nor Github provides said submodules when downloading a zip archive of this repository.

This PR proposes to vendor `hardware.inc` into the `include` directory and adds a `scripts/update_hardware_inc.sh` script to make keeping it update-to-date easy.